### PR TITLE
fix tpaaccept command

### DIFF
--- a/src/main/java/com/fractured/commands/tpa/TpaAcceptCommand.java
+++ b/src/main/java/com/fractured/commands/tpa/TpaAcceptCommand.java
@@ -63,6 +63,6 @@ public final class TpaAcceptCommand
         }
 
         user.setLastLocation(player.getLocation());
-        player.teleport(player);
+        player.teleport(target);
     }
 }


### PR DESCRIPTION
Issue:
/tpaaccept would teleport the player to itself

Fixed:
/tpaaccept now teleports the player to the target